### PR TITLE
Add module documentation and comment cleanup

### DIFF
--- a/README-module.md
+++ b/README-module.md
@@ -1,0 +1,33 @@
+# Module Descriptions
+
+This document briefly describes the purpose of each source file in the project.
+
+- `aes_cfb.c` - AES encryption in CFB mode
+- `aes_generic.c` - Generic AES helper functions
+- `aes_pseudo.c` - AES-based pseudo random generator
+- `bbs_pseudo.c` - Blum Blum Shub pseudo random generator
+- `cache.c` - Bit caching utilities
+- `cell.c` - Cell based pseudo random support
+- `debug.c` - Debugging helpers
+- `decrypt.c` - Core decryption routine
+- `dibit.c` - Command line interface and main processing
+- `diffuser.c` - Data diffusion implementation
+- `encrypt.c` - Core encryption routine
+- `getkey.c` - Command line key extraction
+- `key_file.c` - Key file management
+- `key_mgmt.c` - High level key management
+- `last_block.c` - Obscure final AES block
+- `lfsr.c` - Linear feedback shift register routines
+- `main.c` - Small wrapper for dibit
+- `mf.c` - In-memory file abstraction
+- `pgm_ctx.c` - Program context management
+- `prime_table.c` - Prime number table builder
+- `rabbit.c` - Rabbit stream cipher
+- `rsa.c` - Simple RSA helper code
+- `scrub.c` - Secure file wiping utilities
+- `sha1.c` - SHA1 hash implementation
+- `trivium.c` - Trivium stream cipher
+- `urandom_pseudo.c` - PRNG based on /dev/urandom
+- `util.c` - Basic bit manipulation helpers
+- `wabbit.c` - Rabbit + LFSR file processing
+- `xor.c` - Utility for XOR operations

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ dibit's design goals were thus:
 of information has a certain bit distance to the next bit of relevant 
 information.
 
-For example, if a byte were encoded to a byte, each bit couldn’t be farther
+For example, if a byte were encoded to a byte, each bit couldnâ€™t be farther
 away to the next bit of information than seven bits.
 
 With AES-128, each bit can only get a maximum distance of 127 bits away.
@@ -93,7 +93,7 @@ index.sh to obtain a daily copy of this file. Get the file by
 
 3. key information is provided by key_file.dat. It's a Linux soft-link and
 should point to some huge file. I happen to use a Linux distribution as it's
-large and commony available, but you can use anything. To get the file I use,
+large and commonly available, but you can use anything. To get the file I use,
 do
 
   sudo sh linux.sh
@@ -247,7 +247,7 @@ where:
   WABBIT uses the rabbit stream cipher gf2^128 times an lfsr to xor the data
 
   Note: sha1 is diffused throughout any previous cyphertext before WABBIT
-  encription.
+  encryption.
 
 How strong is the key?
 ----------------------
@@ -261,7 +261,7 @@ Will quantum computers or DNA analysis help decrypt a message?
 
 Possible, but certainly very costly.
 
-Quantum computers are measured in quobits and research has them only at about
+Quantum computers are measured in qubits and research has them only at about
 10 or so of these. This might work on a cypher with a lesser Bit Locality,
 but would have trouble with the long and variable bit lengths in dibit.
 
@@ -281,7 +281,7 @@ Other streams use different algorithms and are pared similarly.
 Finally, all four streams are combined uniquely in the 'Dibit Encryption
 Algorithm'.
 
-Are there any repeating patters in a .dibit file?
+Are there any repeating patterns in a .dibit file?
 -------------------------------------------------
 
 None have been found so far. If you try to compress the file with gzip or bzip2,
@@ -308,7 +308,7 @@ Futures
 
 I can see modifying the final AES_CFB pass to make it byte oriented so that the
 last AES packet in the file can't be guessed. Rarely, the pad algorithm may
-write a 1 followd by 15 0's to the file. This could be guessed and used to
+write a 1 followed by 15 0's to the file. This could be guessed and used to
 determine the master-key.
 
 I can see adding a hash at the end of the file before the last AES_CFB

--- a/main.c
+++ b/main.c
@@ -7,6 +7,11 @@
 
 int trace_flag = 1;
 
+//
+// main - entry point that simply calls dibit_main
+//   argc, argv: standard argument vector passed through
+//   returns value from dibit_main
+//
 int main ( int argc, char *argv[] )
 {
   int sts;

--- a/mf.c
+++ b/mf.c
@@ -1,4 +1,4 @@
-// mf - memory file - mimics open/close/read/writre execpt in memory
+// mf - memory file - mimics open/close/read/write except in memory
 
 #include <sys/mman.h>
 

--- a/scrub.c
+++ b/scrub.c
@@ -98,6 +98,13 @@ static PAT pats[35] = {
 
 static char *f = NULL;
 
+//
+// zorch_file - overwrite a file using a specific pattern or random data
+//   fname : file to modify
+//   flag  : if non-zero fill with random data, otherwise use pat
+//   pat   : data pattern used when flag is zero
+//   xsubi : seed for nrand48 when generating random bytes
+//
 static void zorch_file ( char *fname , int flag, unsigned int pat, unsigned short *xsubi )
 {
   struct stat sb;
@@ -156,7 +163,11 @@ static void zorch_file ( char *fname , int flag, unsigned int pat, unsigned shor
   close(fd);
 }
 
-// scrub
+//
+// scrub - securely erase a file using the Gutmann method
+//   fname : path of file to scrub
+//   xsubi : seed for nrand48 when random patterns are required
+//
 void scrub ( char *fname , unsigned short *xsubi )
 {
   int i;

--- a/util.c
+++ b/util.c
@@ -1,6 +1,11 @@
 #include "util.h"
 
-// get bit
+//
+// get_bit - return a single bit from the given array
+//   array: pointer to the bit array
+//   bitno: bit offset to retrieve
+//   returns: 0 or 1 depending on the value of the bit
+//
 int get_bit ( unsigned char *array, int bitno )
 {
   int off = bitno / 8;
@@ -10,7 +15,11 @@ int get_bit ( unsigned char *array, int bitno )
   return array[off] & mask ? 1 : 0;
 }
 
-// clr bit
+//
+// clr_bit - clear a single bit in the array
+//   array: pointer to the bit array
+//   bitno: bit offset to clear
+//
 void clr_bit ( unsigned char *array, int bitno )
 {
   int off = bitno / 8;
@@ -20,7 +29,12 @@ void clr_bit ( unsigned char *array, int bitno )
   array[off] &= ~mask;
 }
 
-// set bit
+//
+// set_bit - set or clear a bit in the array
+//   array: pointer to the bit array
+//   bitno: bit offset to modify
+//   val  : value to write (0 or 1)
+//
 void set_bit ( unsigned char *array, int bitno, int val )
 {
   int off = bitno / 8;
@@ -30,7 +44,12 @@ void set_bit ( unsigned char *array, int bitno, int val )
   if ( val ) array[off] |= mask;
 }
 
-// set dibit
+//
+// set_dibit - store a two bit value into the array
+//   array: pointer to the dibit array
+//   bitno: dibit offset to modify
+//   val  : value to store (0 or 1)
+//
 void set_dibit ( unsigned char *array, int bitno, int val )
 {
   int off = bitno / 4;
@@ -40,7 +59,12 @@ void set_dibit ( unsigned char *array, int bitno, int val )
   if ( val ) array[off] |= mask;
 }
 
-// get dibit
+//
+// get_dibit - fetch a two bit value from the array
+//   array: pointer to the dibit array
+//   bitno: dibit offset to read
+//   returns: 0 or 1
+//
 int get_dibit ( unsigned char *array, int bitno )
 {
   int off = bitno / 4;
@@ -51,8 +75,13 @@ int get_dibit ( unsigned char *array, int bitno )
 }
 
 
-// copy a chunk of index.html to buf
-// return 0 if we could not do it
+//
+// get_index_html - copy random data from index.html into buf
+//   buf   : output buffer
+//   cnt   : number of bytes to copy
+//   xsubi : seed for nrand48 used to randomize file offsets
+//   returns 1 on success, 0 on failure
+//
 int get_index_html ( char *buf, int cnt, unsigned short *xsubi )
 {
   static int fd = -1;


### PR DESCRIPTION
## Summary
- fix typos in README
- add documentation comments in `util.c`, `scrub.c`, and `main.c`
- correct comment typo in `mf.c`
- add `README-module.md` describing all source files

## Testing
- `make` *(fails: libgcrypt not found)*